### PR TITLE
Fix python installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,12 @@ RUN pip install --upgrade --force-reinstall requests
 
 # Install known working Python packages
 RUN pip install \
-        --no-cache-dir \
+        --no-cache-dir --ignore-installed \
+        --constraint  /opt/stack/requirements/upper-constraints.txt \
+        --requirement /opt/stack/requirements/global-requirements.txt
+
+RUN pip install \
+        --no-cache-dir --ignore-installed \
         --constraint  /opt/stack/requirements/upper-constraints.txt \
         --requirement /opt/stack/requirements/global-requirements.txt \
         --requirement /opt/stack/requirements/test-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,6 @@ RUN pip install \
 RUN pip install \
         --no-cache-dir --ignore-installed \
         --constraint  /opt/stack/requirements/upper-constraints.txt \
-        --requirement /opt/stack/requirements/global-requirements.txt \
         --requirement /opt/stack/requirements/test-requirements.txt
 
 # Setup non-Root user "stack", as required by stack.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,13 +82,13 @@ ARG PROJECTS=" \
 # Clone DevStack, Requirements and OpenStack (Core) Projects
 #  - To properly detect a container environment,
 #    we need at least openstack-dev/devstack/commit/63666a2
-RUN git clone git://git.openstack.org/openstack-dev/devstack --branch $DEVSTACK_BRANCH && \
-    git clone git://git.openstack.org/openstack/requirements --branch $DEVSTACK_BRANCH /opt/stack/requirements && \
+RUN git clone http://github.com/openstack/devstack --branch $DEVSTACK_BRANCH && \
+    git clone http://github.com/openstack/requirements --branch $DEVSTACK_BRANCH /opt/stack/requirements && \
     for \
         PROJECT in $PROJECTS; \
     do \
         git clone \
-            git://git.openstack.org/openstack/$PROJECT.git \
+            http://github.com/openstack/$PROJECT.git \
             /opt/stack/$PROJECT \
             --branch $PROJECTS_BRANCH \
             --depth 1 \


### PR DESCRIPTION
I changed how pip install command is done, separating into tow commands to prevent error related on #6, and also added an option `--ignore-installed` on pip install command to handle with psutil error described on #5.